### PR TITLE
Add calculations for functional and custom economic breakdowns

### DIFF
--- a/lib/gobierto_budgets_data/gobierto_budgets/budget_lines_csv_importer.rb
+++ b/lib/gobierto_budgets_data/gobierto_budgets/budget_lines_csv_importer.rb
@@ -51,7 +51,7 @@ module GobiertoBudgetsData
         @custom_codes_tree ||= rows.inject({}) do |tree, row|
           next(tree) unless row.custom_parent_code? || row.custom_level?
 
-          tree.update(row.code => calculate_custom_parent_codes(row.code))
+          tree.update(row.code => [OpenStruct.new(code: row.code, level: row.level)] + calculate_custom_parent_codes(row.code))
         end
       end
 
@@ -90,7 +90,7 @@ module GobiertoBudgetsData
             economic_parent_codes = if row.economic_custom?
                                       custom_parent_codes(row.economic_code)
                                     else
-                                      row.economic_code_object.parent_codes
+                                      [OpenStruct.new(code: row.economic_code_object.code, level: row.economic_code_object.level)] + row.economic_code_object.parent_codes
                                     end
             code = parent_codes.last.code
 
@@ -99,6 +99,7 @@ module GobiertoBudgetsData
               custom_code = row.economic_custom? ? subcode.code : row.custom_code
 
               accumulate(base_index + [code, functional_code, custom_code, "", 1], row)
+              accumulate(base_index + [row.code, functional_code, custom_code, row.parent_code, row.level], row)
             end
           else
             parent_codes.each do |pc|


### PR DESCRIPTION
With the changes this PR the task accumulates values for all parents of functional/custom code for the last level of each economic code present in the data and for its root parent code level also. In this way all breakdowns can be displayed for all functional/custom codes

This can be verified for this decomposition in
https://cortegada.gobify.net/presupuestos/partidas/13/2010/functional/G
https://cortegada.gobify.net/presupuestos/partidas/15/2010/functional/G
https://cortegada.gobify.net/presupuestos/partidas/22/2010/functional/G
https://cortegada.gobify.net/presupuestos/partidas/2/2010/functional/G
https://cortegada.gobify.net/presupuestos/partidas/1/2010/functional/G

for this original data:

year | code | area | kind | initial_value | modified_value | executed_value | organization_id | functional_code | custom_code
-- | -- | -- | -- | -- | -- | -- | -- | -- | --
2010 | 100-00 | economic-functional | G | 100 | 100 | 100 | 32027 | 13
2010 | 161-03 | economic-functional | G | 200 | 200 | 200 | 32027 | 13
2010 | 162-02 | economic-functional | G | 300 | 300 | 300 | 32027 | 13
2010 | 100-00 | economic-functional | G | 400 | 400 | 400 | 32027 | 22
2010 | 161-03 | economic-functional | G | 500 | 500 | 500 | 32027 | 22
2010 | 162-02 | economic-functional | G | 600 | 600 | 600 | 32027 | 22
2010 | 100-00 | economic-functional | G | 10000 | 10000 | 10000 | 32027 | 15
2010 | 161-03 | economic-functional | G | 20000 | 20000 | 20000 | 32027 | 15
2010 | 162-02 | economic-functional | G | 30000 | 30000 | 30000 | 32027 | 15