### PR TITLE
Fix extra rows when nil

### DIFF
--- a/lib/gobierto_budgets_data/gobierto_budgets/budget_lines_csv_importer.rb
+++ b/lib/gobierto_budgets_data/gobierto_budgets/budget_lines_csv_importer.rb
@@ -126,6 +126,8 @@ module GobiertoBudgetsData
       end
 
       def remove_duplicates
+        return if extra_rows.nil?
+
         extra_rows.each do |row|
           rows.delete_if do |r|
             [:year, :code, :raw_area_name, :kind, :functional_code, :custom_code].all? { |attr| row.send(attr) == r.send(attr) }


### PR DESCRIPTION
This PR fixes an error happenning when there are no extra rows in the imported CSV