### PR TITLE
Importer fixes

### DIFF
--- a/lib/gobierto_budgets_data/gobierto_budgets/budget_line_csv_row.rb
+++ b/lib/gobierto_budgets_data/gobierto_budgets/budget_line_csv_row.rb
@@ -14,7 +14,7 @@ module GobiertoBudgetsData
 
       KIND_VALUES_MAPPING = {
         "I" => INCOME,
-        "G" => EXPENSE
+        "E" => EXPENSE
       }
 
       INDEXES_COLUMNS_NAMES_MAPPING = {

--- a/lib/gobierto_budgets_data/gobierto_budgets/budget_lines_csv_importer.rb
+++ b/lib/gobierto_budgets_data/gobierto_budgets/budget_lines_csv_importer.rb
@@ -9,6 +9,7 @@ module GobiertoBudgetsData
         @csv = csv
         @output = []
         @accumulated_values = {}
+        @extra_rows = []
       end
 
       def import!
@@ -127,8 +128,6 @@ module GobiertoBudgetsData
       end
 
       def remove_duplicates
-        return if extra_rows.nil?
-
         extra_rows.each do |row|
           rows.delete_if do |r|
             [:year, :code, :raw_area_name, :kind, :functional_code, :custom_code].all? { |attr| row.send(attr) == r.send(attr) }


### PR DESCRIPTION
This is a WIP

Fixes:

- the kind Expenses should be mapped to E and not to G, according to the docs https://docs.google.com/spreadsheets/d/1KcPnDg4IwXIxFDfqQNjOZoyt4YZOMoU7pjJ9cURvsms/edit#gid=1814697166
- when the CSV contains extra rows with empty values the importer was failing

There are still issues to be fixed:

- it looks like when upper levels are calculated, the kind is not propagated for expenses, so level 3, 2 and 1 for expenses are empty after the import