### PR TITLE
Skip non exitsting custom intermediate codes in extra rows

### DIFF
--- a/lib/gobierto_budgets_data/gobierto_budgets/budget_lines_csv_importer.rb
+++ b/lib/gobierto_budgets_data/gobierto_budgets/budget_lines_csv_importer.rb
@@ -125,7 +125,7 @@ module GobiertoBudgetsData
             "ID" => nil
           )
           BudgetLineCsvRow.new(CSV::Row.new(row_values.keys, row_values.values))
-        end
+        end.reject(&:unavailable_custom_category?)
       end
 
       def remove_duplicates


### PR DESCRIPTION
This PR avoids the import of data  calculated in aggregations related with intermediate custom codes without a category defined in database