### PR TITLE
Restore cleanup of "remantes" budget lines

### DIFF
--- a/lib/gobierto_budgets_data/gobierto_budgets/utils/sicalwin_budget_line_processor.rb
+++ b/lib/gobierto_budgets_data/gobierto_budgets/utils/sicalwin_budget_line_processor.rb
@@ -37,6 +37,15 @@ module GobiertoBudgetsData
             rows_repository[area_name] ||= {}
 
             @raw_rows.each do |row|
+              # Skip remanentes rows when the file is expense
+              if kind == GobiertoBudgetsData::GobiertoBudgets::EXPENSE
+                if row.row["Remanentes Incorporados"].present? && row.row["Remanentes Incorporados"].to_f > 0 &&
+                    row.row["Créditos Iniciales"].present? && row.row["Créditos Iniciales"].to_f == 0
+                  puts "Skipping remanentes row: #{row.inspect}"
+                  next
+                end
+              end
+
               code = row.area_code(area_name)
 
               # Import the custom category description using the three parts organic + program + economic


### PR DESCRIPTION
This PR reverts this snippet of code I deleted by mistake, related with the cleanup of the budget lines that should not be imported because are referring to other years data.