### PR TITLE
Avoid sending an empty body to SearchEngineWriting bulk client operation

### DIFF
--- a/lib/gobierto_budgets_data/gobierto_budgets/budget_lines_importer.rb
+++ b/lib/gobierto_budgets_data/gobierto_budgets/budget_lines_importer.rb
@@ -34,9 +34,11 @@ module GobiertoBudgetsData
           })
         end
 
-        response = GobiertoBudgetsData::GobiertoBudgets::SearchEngineWriting.client.bulk(body: budget_lines)
+        if budget_lines.present?
+          GobiertoBudgetsData::GobiertoBudgets::SearchEngineWriting.client.bulk(body: budget_lines)
+        end
 
-        return budget_lines.length
+        budget_lines.length
       end
     end
   end

--- a/lib/gobierto_budgets_data/gobierto_budgets/invoices_importer.rb
+++ b/lib/gobierto_budgets_data/gobierto_budgets/invoices_importer.rb
@@ -35,7 +35,7 @@ module GobiertoBudgetsData
               _index: index,
               _id: id,
               _type: type,
-              data: attributes,
+              data: attributes
             }
           )
 
@@ -44,7 +44,7 @@ module GobiertoBudgetsData
             invoices = []
           end
         end
-        GobiertoBudgetsData::GobiertoBudgets::SearchEngineWriting.client.bulk(body: invoices)
+        GobiertoBudgetsData::GobiertoBudgets::SearchEngineWriting.client.bulk(body: invoices) if invoices.present?
 
         nitems
       end


### PR DESCRIPTION
This PR avoids sending an empty body to SearchEngineWriting.client` `bulk` operation which generates an error response.

This is already [solved in other parts of the code](https://github.com/PopulateTools/gobierto_budgets_data/blob/ef0dee01e80f2b240c602cdd825994426adb1ea2/lib/gobierto_budgets_data/gobierto_budgets/budget_lines_sicalwin_importer.rb#L22-L24). The PR covers the rest of calls to `SearchEngineWriting.client.bulk` 