### PR TITLE
Extend bubbles calculations to different levels and areas

### DIFF
--- a/lib/gobierto_budgets_data/gobierto_budgets/bubbles.rb
+++ b/lib/gobierto_budgets_data/gobierto_budgets/bubbles.rb
@@ -34,6 +34,8 @@ module GobiertoBudgetsData
       end
 
       def build_data_file
+        return if max_year_level.blank?
+
         expense_lines[max_year_level].group_by(&:code).each do |code, lines|
           fill_data_for(code, lines, GobiertoBudgetsData::GobiertoBudgets::EXPENSE, @expense_lines_area_name)
         end
@@ -48,7 +50,7 @@ module GobiertoBudgetsData
                               expense_max_years = expense_lines.transform_values { |lines| lines.map(&:year).max }
                               income_max_years = income_lines.transform_values { |lines| lines.map(&:year).max }
 
-                              max_years = expense_max_years.merge(income_max_years) { |_k, v1, v2| [v1, v2].max  }
+                              max_years = expense_max_years.merge(income_max_years) { |_k, v1, v2| [v1, v2].max }.compact_blank
                               max_year = max_years.values.max
 
                               max_years.select { |k, v| v == max_year }.keys.max
@@ -72,9 +74,9 @@ module GobiertoBudgetsData
                                end
                              end
 
-                             max_years_by_area = data_by_area.transform_values{|r| r.transform_values { |lines| lines.map(&:year).max }.values.max }
+                             max_years_by_area = data_by_area.transform_values { |r| r.transform_values { |lines| lines.map(&:year).compact.max }.values.compact.max }.compact_blank
                              max_year = max_years_by_area.values.max
-                             @expense_lines_area_name = max_years_by_area.select { |_area_name, year| year == max_year }.keys.first
+                             @expense_lines_area_name = max_years_by_area.select { |_area_name, year| year == max_year }.keys.first || GobiertoBudgetsData::GobiertoBudgets::FUNCTIONAL_AREA_NAME
                              data_by_area[@expense_lines_area_name]
                            end
       end

--- a/lib/gobierto_budgets_data/gobierto_budgets/bubbles.rb
+++ b/lib/gobierto_budgets_data/gobierto_budgets/bubbles.rb
@@ -3,6 +3,8 @@
 module GobiertoBudgetsData
   module GobiertoBudgets
     class Bubbles
+      CATEGORIES_LEVELS = [1, 2]
+
       def self.dump(organization_id)
         bubble_data_builder = new(organization_id)
         bubble_data_builder.build_data_file
@@ -32,61 +34,100 @@ module GobiertoBudgetsData
       end
 
       def build_data_file
-        expense_lines.group_by(&:code).each do |code, lines|
-          fill_data_for(code, lines, GobiertoBudgetsData::GobiertoBudgets::EXPENSE)
+        expense_lines[max_year_level].group_by(&:code).each do |code, lines|
+          fill_data_for(code, lines, GobiertoBudgetsData::GobiertoBudgets::EXPENSE, @expense_lines_area_name)
         end
 
-        income_lines.each.group_by(&:code).uniq.each do |code, lines|
+        income_lines[max_year_level].each.group_by(&:code).uniq.each do |code, lines|
           fill_data_for(code, lines, GobiertoBudgetsData::GobiertoBudgets::INCOME)
         end
       end
 
+      def max_year_level
+        @max_year_level ||= begin
+                              expense_max_years = expense_lines.transform_values { |lines| lines.map(&:year).max }
+                              income_max_years = income_lines.transform_values { |lines| lines.map(&:year).max }
+
+                              max_years = expense_max_years.merge(income_max_years) { |_k, v1, v2| [v1, v2].max  }
+                              max_year = max_years.values.max
+
+                              max_years.select { |k, v| v == max_year }.keys.max
+                            end
+      end
+
       def expense_lines
-        hits = expense_lines_hits(false)
+        @expense_lines ||= begin
+                             data_by_area = [
+                               GobiertoBudgetsData::GobiertoBudgets::FUNCTIONAL_AREA_NAME,
+                               GobiertoBudgetsData::GobiertoBudgets::ECONOMIC_AREA_NAME
+                             ].each_with_object({}) do |area_name, area_data|
+                               area_data[area_name] = CATEGORIES_LEVELS.each_with_object({}) do |level, data|
+                                 hits = expense_lines_hits(updated_forecast: false, level: level, area_name: area_name)
 
-        expense_lines_hits.each do |original_hit|
-          hits << original_hit if hits.none? { |h| hit_id(h) == hit_id(original_hit) }
-        end
+                                 expense_lines_hits(level: level, area_name: area_name).each do |original_hit|
+                                   hits << original_hit if hits.none? { |h| hit_id(h) == hit_id(original_hit) }
+                                 end
 
-        hits
+                                 data[level] = hits
+                               end
+                             end
+
+                             max_years_by_area = data_by_area.transform_values{|r| r.transform_values { |lines| lines.map(&:year).max }.values.max }
+                             max_year = max_years_by_area.values.max
+                             @expense_lines_area_name = max_years_by_area.select { |_area_name, year| year == max_year }.keys.first
+                             data_by_area[@expense_lines_area_name]
+                           end
+      end
+
+      def expense_lines_area_name
+        @expense_lines_area_name ||= expense_lines && @expense_lines_area_name
       end
 
       def income_lines
-        hits = income_lines_hits(false)
+        @income_lines ||= CATEGORIES_LEVELS.each_with_object({}) do |level, data|
+          hits = income_lines_hits(updated_forecast: false, level: level)
 
-        income_lines_hits.each do |original_hit|
-          hits << original_hit if hits.none? { |h| hit_id(h) == hit_id(original_hit) }
+          income_lines_hits(level: level).each do |original_hit|
+            hits << original_hit if hits.none? { |h| hit_id(h) == hit_id(original_hit) }
+          end
+
+          data[level] = hits
         end
-
-        hits
       end
 
       def hit_id(hit)
         [hit.year, hit.kind, hit.area_name, hit.code].join("/")
       end
 
-      def expense_lines_hits(updated_forecast = false)
+      def expense_lines_hits(options = {})
+        level = options[:level] || 2
+        updated_forecast = options[:updated_forecast] || false
+        area_name = options[:area_name] || GobiertoBudgetsData::GobiertoBudgets::ECONOMIC_AREA_NAME
+
         GobiertoBudgetsData::GobiertoBudgets::BudgetLine.all(
           organization_id: organization_id,
           kind: GobiertoBudgetsData::GobiertoBudgets::EXPENSE,
-          area_name: GobiertoBudgetsData::GobiertoBudgets::FUNCTIONAL_AREA_NAME,
-          level: 2,
+          area_name: area_name,
+          level: level,
           updated_forecast: updated_forecast
         )
       end
 
-      def income_lines_hits(updated_forecast = false)
+      def income_lines_hits(options = {})
+        level = options[:level] || 2
+        updated_forecast = options[:updated_forecast] || false
         GobiertoBudgetsData::GobiertoBudgets::BudgetLine.all(
           organization_id: organization_id,
           kind: GobiertoBudgetsData::GobiertoBudgets::INCOME,
           area_name: GobiertoBudgetsData::GobiertoBudgets::ECONOMIC_AREA_NAME,
-          level: 2,
+          level: level,
           updated_forecast: updated_forecast
         )
       end
 
-      def expense_categories(locale)
-        GobiertoBudgetsData::GobiertoBudgets::Category.all(locale: locale, area_name: GobiertoBudgetsData::GobiertoBudgets::FUNCTIONAL_AREA_NAME, kind: GobiertoBudgetsData::GobiertoBudgets::EXPENSE)
+      def expense_categories(locale, area_name = nil)
+        area_name ||= GobiertoBudgetsData::GobiertoBudgets::FUNCTIONAL_AREA_NAME
+        GobiertoBudgetsData::GobiertoBudgets::Category.all(locale: locale, area_name: area_name, kind: GobiertoBudgetsData::GobiertoBudgets::EXPENSE)
       end
 
       def income_categories(locale)
@@ -99,15 +140,20 @@ module GobiertoBudgetsData
         "Ingresos patrimoniales" if code.starts_with?("5")
       end
 
-      def localized_name_for(locale, code, kind)
+      def localized_name_for(locale, code, kind, area_name = nil)
         if kind == GobiertoBudgetsData::GobiertoBudgets::INCOME
           income_categories(locale)[code]
         else
-          expense_categories(locale)[code]
+          expense_categories(locale, area_name)[code]
         end
       end
 
-      def fill_data_for(code, budget_lines, kind)
+      def fill_data_for(code, budget_lines, kind, area_name = nil)
+        area_name ||= if kind == GobiertoBudgetsData::GobiertoBudgets::EXPENSE
+                        GobiertoBudgetsData::GobiertoBudgets::FUNCTIONAL_AREA_NAME
+                      else
+                        GobiertoBudgetsData::GobiertoBudgets::ECONOMIC_AREA_NAME
+                      end
         values = {}
         values_per_inhabitant = {}
         years = budget_lines.map(&:year).sort.reverse
@@ -133,14 +179,15 @@ module GobiertoBudgetsData
 
         data = {
           budget_category: kind == GobiertoBudgetsData::GobiertoBudgets::EXPENSE ? "expense" : "income",
+          area_name: area_name,
           id: code.to_s,
           "pct_diff": pct_diff,
           "values": values,
           "values_per_inhabitant": values_per_inhabitant
         }
 
-        data[:level_2_es] = localized_name_for(:es, code, kind)
-        data[:level_2_ca] = localized_name_for(:ca, code, kind)
+        data[:level_2_es] = localized_name_for(:es, code, kind, area_name)
+        data[:level_2_ca] = localized_name_for(:ca, code, kind, area_name)
 
         @file_content.push(data)
       end


### PR DESCRIPTION
This PR changes the bubbles calculation by place to take into account the data availability:
* By default the data is generated for categories of level 2. If the latest year in incomes or expenses only have level 1 data then all the data is generated for categories of level 1
* Similarly, if there is no data of expense in functional area in the most recent year but there is data of economic area then all the expenses for the place are calculated for economic area instead of the functional default area
* The data adds an attribute with the area to be used by the charts to generate the paths of the budget lines. This attribute is also used to generate the correct translations of the categories 

The data generated can be checked for Iekora which has only level 1 data and functional expenses data is missing: https://gobierto-populate-staging.s3.eu-west-1.amazonaws.com/gobierto_budgets/1060/data/bubbles.json