### PR TITLE
Add method to get the result of searching population data

### DIFF
--- a/lib/gobierto_budgets_data/gobierto_budgets/population.rb
+++ b/lib/gobierto_budgets_data/gobierto_budgets/population.rb
@@ -3,17 +3,47 @@
 module GobiertoBudgetsData
   module GobiertoBudgets
     class Population
+      INDEX = GobiertoBudgetsData::GobiertoBudgets::ES_INDEX_DATA
+      TYPE = GobiertoBudgetsData::GobiertoBudgets::POPULATION_TYPE
+      ALLOWED_SEARCH_KEYS = [:organization_id, :ine_code, :year, :province_id, :autonomy_id]
+
       def self.get(ine_code, year)
-        index = GobiertoBudgetsData::GobiertoBudgets::ES_INDEX_DATA
-        type  = GobiertoBudgetsData::GobiertoBudgets::POPULATION_TYPE
-        client = GobiertoBudgetsData::GobiertoBudgets::SearchEngine.client
         year.downto(year-2).each do |current_year|
           begin
-            return client.get(index: index, id: [ine_code, current_year, type].join('/'))['_source']['value']
+            return client.get(index: INDEX, id: [ine_code, current_year, TYPE].join('/'))['_source']['value']
           rescue Elasticsearch::Transport::Transport::Errors::NotFound
           end
         end
         return nil
+      end
+
+      # Returns a result of searching by population type and any of the allowed
+      # search keys
+      def self.get_by(options = {})
+        terms = [{ term: { type: "population" } }]
+
+        options.slice(*ALLOWED_SEARCH_KEYS).each do |term, value|
+          terms << { term: { term => value } }
+        end
+
+        body = {
+          query: { bool: { must: terms } },
+          size: 10_000
+        }
+
+        result = begin
+          client.search(
+            index: INDEX,
+            body: body
+          )
+        rescue Elasticsearch::Transport::Transport::Errors::NotFound
+        end
+
+        result.presence && result["hits"]["hits"]
+      end
+
+      def self.client
+        GobiertoBudgetsData::GobiertoBudgets::SearchEngine.client
       end
     end
   end


### PR DESCRIPTION
This PR adds a method to get the result of searching population data.

Instead of responding with the value of population at an specific id the new method allows to return the data filtered by location, province, autonomous region or year to avoid requests to the elasticsearch service